### PR TITLE
mysql2pg W2: dialect-aware DB connection (worker + conductor)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && \
 
 RUN pip install --no-cache-dir \
       numpy==1.22.4 scipy==1.8.1 scikit-image==0.19.3 soundfile==0.12.1 \
-      sqlalchemy==1.4.52 mysql-connector-python==8.1.0 boto3==1.28.71
+      sqlalchemy==1.4.52 mysql-connector-python==8.1.0 boto3==1.28.71 \
+      psycopg2-binary==2.9.9
 
 WORKDIR /app
 COPY functions/worker/ /app/

--- a/functions/conductor/db.py
+++ b/functions/conductor/db.py
@@ -1,7 +1,16 @@
 import os
+from urllib.parse import quote_plus
+
 from sqlalchemy import create_engine, MetaData
 from sqlalchemy.orm import sessionmaker
 from secrets import aws_secrets
+
+# mysql2pg Phase 5.5 (W2, 2026-07-16): dialect-aware connection, kept in
+# lockstep with functions/worker/db.py. NOTE: in rfcx-local the conductor
+# path is DEAD (no image builds functions/conductor/; arbimon-legacy's
+# enqueueAEDClusteringJob inserts the type-8 jobs row directly and the
+# jobqueue-dispatcher claims it). Ported anyway so the two db.py copies
+# never diverge on dialect handling if this path is ever resurrected.
 
 def connect():
 
@@ -10,16 +19,26 @@ def connect():
     if secret_name: params = aws_secrets(secret_name)
     else: params = os.environ
     host     = params.get('host')
-    port     = str(params.get('port', '3306'))
+    port     = str(os.environ.get('ARBIMON_DB_PORT') or params.get('port', '3306'))
     schema   = params.get('schema')
-    user     = 'tm_driver'
+    user     = os.environ.get('ARBIMON_DB_USER', 'tm_driver')
     password = params.get('tm_driver_pwd')
 
     if not all(params):
         raise Exception('Connection parameters invalid', [host, port, schema, user, password])
 
     # Establish connection and return session
-    engine = create_engine('mysql+mysqlconnector://' + user + ':' + password + '@' + host + ':' + port + '/' + schema)
+    dialect = os.environ.get('ARBIMON_DB_DIALECT', 'mysql').lower()
+    if dialect in ('postgres', 'postgresql', 'pg'):
+        engine = create_engine(
+            'postgresql+psycopg2://' + quote_plus(user) + ':'
+            + quote_plus(password) + '@' + host + ':' + port + '/' + schema,
+            connect_args={'connect_timeout': 10},
+            executemany_mode='values_plus_batch')
+    else:
+        engine = create_engine(
+            'mysql+mysqlconnector://' + quote_plus(user) + ':'
+            + quote_plus(password) + '@' + host + ':' + port + '/' + schema)
     Session = sessionmaker(bind=engine, autocommit=False)
     metadata = MetaData()
     return Session(), engine, metadata

--- a/functions/worker/db.py
+++ b/functions/worker/db.py
@@ -1,7 +1,18 @@
 import os
+from urllib.parse import quote_plus
+
 from sqlalchemy import create_engine, MetaData
 from sqlalchemy.orm import sessionmaker
 aws_secrets = None  # AWS Secrets Manager optional; use env
+
+# mysql2pg Phase 5.5 (W2, 2026-07-16): dialect-aware connection.
+# ARBIMON_DB_DIALECT=mysql (DEFAULT - byte-for-byte today's behavior) or
+# postgres. The PG path activates ONLY via env at the coordinated jobs-plane
+# flip; nothing changes for existing deploys. Env names stay the same for
+# both dialects (host/port/schema/tm_driver_pwd/ARBIMON_DB_USER; the flip
+# changes env VALUES, not names; ARBIMON_DB_PORT overrides port when set).
+# Credentials are URL-quoted (quote_plus): the string-concat URL breaks on
+# any password containing URL-special characters (found by the W1 smoke).
 
 def connect():
 
@@ -10,7 +21,7 @@ def connect():
     if False: params = None
     params = os.environ
     host     = params.get('host')
-    port     = str(params.get('port', '3306'))
+    port     = str(os.environ.get('ARBIMON_DB_PORT') or params.get('port', '3306'))
     schema   = params.get('schema')
     user     = os.environ.get('ARBIMON_DB_USER', 'tm_driver')
     password = params.get('tm_driver_pwd')
@@ -19,7 +30,20 @@ def connect():
         raise Exception('Connection parameters invalid', [host, port, schema, user, password])
 
     # Establish connection and return session
-    engine = create_engine('mysql+mysqlconnector://' + user + ':' + password + '@' + host + ':' + port + '/' + schema)
+    dialect = os.environ.get('ARBIMON_DB_DIALECT', 'mysql').lower()
+    if dialect in ('postgres', 'postgresql', 'pg'):
+        # executemany_mode: every session.execute(table.insert(), [dicts])
+        # bulk path (detections / playlist_aed) becomes multi-row VALUES on
+        # PG (worker-port template rule 4) without touching call sites.
+        engine = create_engine(
+            'postgresql+psycopg2://' + quote_plus(user) + ':'
+            + quote_plus(password) + '@' + host + ':' + port + '/' + schema,
+            connect_args={'connect_timeout': 10},
+            executemany_mode='values_plus_batch')
+    else:
+        engine = create_engine(
+            'mysql+mysqlconnector://' + quote_plus(user) + ':'
+            + quote_plus(password) + '@' + host + ':' + port + '/' + schema)
     Session = sessionmaker(bind=engine, autocommit=False)
     metadata = MetaData()
     return Session(), engine, metadata


### PR DESCRIPTION
Part of the arbimon2 MariaDB→PostgreSQL migration (rfcx-local Phase 5.5 jobs-plane flip; worker-port template W2).

**Zero behavior change today:** `ARBIMON_DB_DIALECT` defaults to `mysql` → identical engine URL and code path. The postgres path activates only via env at the coordinated flip. Additionally, live deploys are pinned (dispatcher `AED_IMAGE_TAG` + aed-consumer image are explicit tags, not `-latest`), so this merge changes no running pod even after CD builds.

- **functions/worker/db.py + functions/conductor/db.py (lockstep):** dialect-gated engine; `ARBIMON_DB_PORT` override; credentials URL-quoted (string-concat DSNs break on URL-special passwords — found by the W1 clustering smoke); PG engine sets `executemany_mode='values_plus_batch'` so the bulk `session.execute(table.insert(), [dicts])` paths (detections / playlist_aed) become multi-row VALUES on PG with no call-site changes. The conductor path is dead in rfcx-local (legacy inserts type-8 jobs directly) but is ported in lockstep so the two db.py copies never diverge.
- **Dockerfile:** + `psycopg2-binary==2.9.9`.
- The worker db.py preserves the exact strings the rfcx-local `aed.Dockerfile` build-time seds target (now no-ops — verified all 3), so the production queue-path build is unaffected.

**Validation:** RO smoke against BOTH live engines — reflection, the worker/driver/consumer read paths, and compilation of all 14 write statements (incl. the gated finalize + the idempotent shard deletes) green on both dialects; aedc count 219,009,079 = 219,009,079. recordings.datetime returns datetime objects on PG (vs the driver-dependent MySQL path) — the unit-circle conversion is None-safe and datetime-safe, no change needed. Write/locking paths get exercised in the Phase-5.5 scratch-DB rehearsal.