### PR TITLE
[DRAFT/flip-train] mysql2pg BLOCKER: AED insert writes uri_vector, not phantom uri_image

### DIFF
--- a/aed_run_job.py
+++ b/aed_run_job.py
@@ -124,7 +124,7 @@ def main(job_id):
                     'job_id': int(job_id), 'recording_id': int(rec_ids[n]),
                     'time_min': float(t[ob[1].start]), 'time_max': float(t[ob[1].stop - 1]),
                     'frequency_min': float(f[ob[0].start]), 'frequency_max': float(f[ob[0].stop - 1]),
-                    'aed_number': int(c), 'uri_image': image_uri + str(c) + '.png',
+                    'aed_number': int(c), 'uri_vector': '',  # mysql2pg B1: real NOT-NULL col (was phantom uri_image)
                 } for c, ob in enumerate(objs)])
                 session.commit()
                 compute_features(objs, rec_ids[n], rec_dts[n], S, f, t, feature_prefix)

--- a/functions/worker/aed_batch.py
+++ b/functions/worker/aed_batch.py
@@ -104,7 +104,17 @@ def handler(event, context):
                       'frequency_min': float(f[ob[0].start]),
                       'frequency_max': float(f[ob[0].stop-1]),
                       'aed_number': int(c),
-                      'uri_image': image_uri+str(c)+'.png'
+                      # mysql2pg BLOCKER B1 fix (2026-07-16 adversarial review):
+                      # the real column is uri_vector (varchar NOT NULL, no
+                      # default) on BOTH engines; there is no uri_image column.
+                      # SQLAlchemy silently DROPPED the bogus uri_image key AND
+                      # omitted uri_vector -> on MariaDB (blank/non-strict
+                      # sql_mode) uri_vector was auto-filled '' (live rows
+                      # confirm), but on PostgreSQL it raises NotNullViolation.
+                      # Writing '' here is byte-identical to today's MySQL rows.
+                      # (The frontend rebuilds the PNG URL from
+                      # job_id/recording_id/aed_number, not from a DB column.)
+                      'uri_vector': ''
                      }
         
                      for c, ob in enumerate(objs)]


### PR DESCRIPTION
**DRAFT — do NOT merge until the mysql2pg Phase 5.5 flip train.** Found by the 2026-07-16 READ-ONLY adversarial worker-port review (BLOCKER B1).

## Problem
The AED detection insert builds a dict with key `uri_image`, which is **not a column** on either engine, and **omits the NOT-NULL column `uri_vector`**. SQLAlchemy Core silently drops the unknown key and omits the missing column, so the insert lacks uri_vector.
- **MariaDB (blank/non-strict sql_mode):** missing NOT-NULL `uri_vector` silently filled `''` (confirmed on live prod type-8 rows).
- **PostgreSQL:** `uri_vector` NOT NULL, no default, no trigger → **NotNullViolation** on every AED job with detections. The mysql2pg PG path is fully broken for type-8.

The port smoke's EXPLAIN pass was a false negative (EXPLAIN doesn't enforce NOT NULL).

## Fix
Write `'uri_vector': ''` (byte-identical to today's MySQL rows; the discarded uri_image key changed nothing). Applied to functions/worker/aed_batch.py + aed_run_job.py.

## Verified
Live schema (postgres-1-0 + mariadb-1-0) both lack uri_image; uri_vector NOT NULL no default no trigger. SQLAlchemy 1.4.52 compile confirms the omission.

NOTE: the rfcx-local built image also carries _patches/aed/aed_consume.py + _patches/aed-run_job.py with the same bug — fixed in a companion rfcx-local PR.