### PR TITLE
fix: detection insert writes uri_param=aed_number (blank clustering ROI grid)

### DIFF
--- a/aed_run_job.py
+++ b/aed_run_job.py
@@ -124,7 +124,12 @@ def main(job_id):
                     'job_id': int(job_id), 'recording_id': int(rec_ids[n]),
                     'time_min': float(t[ob[1].start]), 'time_max': float(t[ob[1].stop - 1]),
                     'frequency_min': float(f[ob[0].start]), 'frequency_max': float(f[ob[0].stop - 1]),
-                    'aed_number': int(c), 'uri_vector': '',  # mysql2pg B1: real NOT-NULL col (was phantom uri_image)
+                    # uri_vector: mysql2pg B1, real NOT-NULL col (was phantom uri_image).
+                    # uri_param: the clustering UI builds the ROI PNG URL from
+                    # this column (CONCAT ... uri_param, '.png'); PNGs are keyed
+                    # by aed_number, so uri_param = aed_number. NULL => blank
+                    # ROI grid (2026-07-18 user-reported regression fix).
+                    'aed_number': int(c), 'uri_vector': '', 'uri_param': int(c),
                 } for c, ob in enumerate(objs)])
                 session.commit()
                 compute_features(objs, rec_ids[n], rec_dts[n], S, f, t, feature_prefix)

--- a/functions/worker/aed_batch.py
+++ b/functions/worker/aed_batch.py
@@ -112,9 +112,18 @@ def handler(event, context):
                       # sql_mode) uri_vector was auto-filled '' (live rows
                       # confirm), but on PostgreSQL it raises NotNullViolation.
                       # Writing '' here is byte-identical to today's MySQL rows.
-                      # (The frontend rebuilds the PNG URL from
-                      # job_id/recording_id/aed_number, not from a DB column.)
-                      'uri_vector': ''
+                      'uri_vector': '',
+                      # 2026-07-18 blank-ROI fix: the arbimon-legacy clustering
+                      # grid builds the ROI PNG URL from the uri_param COLUMN
+                      # (findRois: CONCAT('audio_events/<env>/detection/',
+                      # job_id, '/png/', recording_id, '/', uri_param, '.png')).
+                      # Omitting it => NULL => .../null.png => blank spectrogram
+                      # grid (user-reported; jobs 167492..167911 backfilled).
+                      # store_roi_images uploads PNGs keyed by the enumerate
+                      # index == aed_number, so uri_param must equal aed_number
+                      # (verified: all pre-regression rows have
+                      # uri_param == aed_number, 0 mismatches).
+                      'uri_param': int(c)
                      }
         
                      for c, ob in enumerate(objs)]


### PR DESCRIPTION
**User-reported (2026-07-18):** the clustering page's ROI spectrogram thumbnails render blank.

**Root cause:** the arbimon-legacy frontend builds each ROI thumbnail URL from the `uri_param` column (`CONCAT('audio_events/<env>/detection/', job_id, '/png/', recording_id, '/', uri_param, '.png')`), but the detection insert never set `uri_param` → NULL → `.../null.png` → blank grid. The PNGs themselves are uploaded correctly by `store_roi_images`, keyed by the enumerate index == `aed_number`.

**Fix:** insert `uri_param = aed_number` in both paths (`functions/worker/aed_batch.py` + `aed_run_job.py`). This is the historical contract — all pre-regression rows have `uri_param == aed_number` (38,489 rows checked, 0 mismatches, matching legacy AWS-era rows).

This restores the June c0c51f3 fix from the `rfcx-local/aws-free-worker` branch that was lost when production images were rebuilt from main — landing it on main makes the contract rebase-proof. Complements #6 (the `uri_vector` NOT-NULL half of the same phantom-`uri_image` bug).

Production impact already remediated separately: 130,123 rows across 24 jobs (2026-06-25 → 2026-07-16) backfilled with `uri_param = aed_number`; deployed worker image already carries this fix via the rfcx-local overlay.